### PR TITLE
エラーダイアログの詳細ダイアログ部をFXMLに分離等

### DIFF
--- a/src/jp/seraphyware/utils/ErrorDialogExpandableContent.fxml
+++ b/src/jp/seraphyware/utils/ErrorDialogExpandableContent.fxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.layout.*?>
+<GridPane xmlns="http://javafx.com/javafx/8.0.112">
+    <rowConstraints>
+        <RowConstraints/>
+        <RowConstraints/>
+    </rowConstraints>
+    <columnConstraints>
+        <ColumnConstraints/>
+    </columnConstraints>
+    <Label text="The exception stacktrace was:"/>
+    <TextArea editable="false" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
+              wrapText="true" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.vgrow="ALWAYS"/>
+</GridPane>

--- a/src/jp/seraphyware/utils/ErrorDialogUtils.java
+++ b/src/jp/seraphyware/utils/ErrorDialogUtils.java
@@ -1,8 +1,5 @@
 package jp.seraphyware.utils;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Label;
@@ -10,51 +7,54 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 public final class ErrorDialogUtils {
 
-	private ErrorDialogUtils() {
-		super();
-	}
+    private ErrorDialogUtils() {
+        super();
+    }
 
-	public static void showException(Throwable ex) {
-		if (ex == null) {
-			return;
-		}
+    public static void showException(Throwable ex) {
+        if (ex == null) {
+            return;
+        }
 
-		// jdk1.8u40から、Alertクラスによるダイアログがサポートされた.
-		// 使い方は以下引用
-		// http://code.makery.ch/blog/javafx-dialogs-official/
+        // jdk1.8u40から、Alertクラスによるダイアログがサポートされた.
+        // 使い方は以下引用
+        // http://code.makery.ch/blog/javafx-dialogs-official/
 
-		Alert alert = new Alert(AlertType.ERROR);
-		alert.setTitle("Exception Dialog");
-		alert.setHeaderText(ex.getClass().getName());
-		alert.setContentText(ex.getMessage());
+        Alert alert = new Alert(AlertType.ERROR);
+        alert.setTitle("Exception Dialog");
+        alert.setHeaderText(ex.getClass().getName());
+        alert.setContentText(ex.getMessage());
 
-		// Create expandable Exception.
-		StringWriter sw = new StringWriter();
-		PrintWriter pw = new PrintWriter(sw);
-		ex.printStackTrace(pw);
-		String exceptionText = sw.toString();
+        // Create expandable Exception.
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ex.printStackTrace(pw);
+        String exceptionText = sw.toString();
 
-		Label label = new Label("The exception stacktrace was:");
+        Label label = new Label("The exception stacktrace was:");
 
-		TextArea textArea = new TextArea(exceptionText);
-		textArea.setEditable(false);
-		textArea.setWrapText(true);
+        TextArea textArea = new TextArea(exceptionText);
+        textArea.setEditable(false);
+        textArea.setWrapText(true);
 
-		textArea.setMaxWidth(Double.MAX_VALUE);
-		textArea.setMaxHeight(Double.MAX_VALUE);
-		GridPane.setVgrow(textArea, Priority.ALWAYS);
-		GridPane.setHgrow(textArea, Priority.ALWAYS);
+        textArea.setMaxWidth(Double.MAX_VALUE);
+        textArea.setMaxHeight(Double.MAX_VALUE);
+        GridPane.setVgrow(textArea, Priority.ALWAYS);
+        GridPane.setHgrow(textArea, Priority.ALWAYS);
 
-		GridPane expContent = new GridPane();
-		expContent.setMaxWidth(Double.MAX_VALUE);
-		expContent.add(label, 0, 0);
-		expContent.add(textArea, 0, 1);
+        GridPane expContent = new GridPane();
+        expContent.setMaxWidth(Double.MAX_VALUE);
+        expContent.add(label, 0, 0);
+        expContent.add(textArea, 0, 1);
 
-		// Set expandable Exception into the dialog pane.
-		alert.getDialogPane().setExpandableContent(expContent);
+        // Set expandable Exception into the dialog pane.
+        alert.getDialogPane().setExpandableContent(expContent);
 
-		alert.showAndWait();
-	}
+        alert.showAndWait();
+    }
 }

--- a/src/jp/seraphyware/utils/ErrorDialogUtils.java
+++ b/src/jp/seraphyware/utils/ErrorDialogUtils.java
@@ -1,12 +1,12 @@
 package jp.seraphyware.utils;
 
+import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Priority;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -16,7 +16,7 @@ public final class ErrorDialogUtils {
         super();
     }
 
-    public static void showException(Throwable ex) {
+    public static void showException(Throwable ex) throws IOException {
         if (ex == null) {
             return;
         }
@@ -30,27 +30,15 @@ public final class ErrorDialogUtils {
         alert.setHeaderText(ex.getClass().getName());
         alert.setContentText(ex.getMessage());
 
+        GridPane expContent = new FXMLLoader(ErrorDialogUtils.class.getResource("ErrorDialogExpandableContent.fxml")).load();
+
         // Create expandable Exception.
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        ex.printStackTrace(pw);
-        String exceptionText = sw.toString();
-
-        Label label = new Label("The exception stacktrace was:");
-
-        TextArea textArea = new TextArea(exceptionText);
-        textArea.setEditable(false);
-        textArea.setWrapText(true);
-
-        textArea.setMaxWidth(Double.MAX_VALUE);
-        textArea.setMaxHeight(Double.MAX_VALUE);
-        GridPane.setVgrow(textArea, Priority.ALWAYS);
-        GridPane.setHgrow(textArea, Priority.ALWAYS);
-
-        GridPane expContent = new GridPane();
-        expContent.setMaxWidth(Double.MAX_VALUE);
-        expContent.add(label, 0, 0);
-        expContent.add(textArea, 0, 1);
+        try (StringWriter sw = new StringWriter()) {
+            try (PrintWriter pw = new PrintWriter(sw)) {
+                ex.printStackTrace(pw);
+            }
+            ((TextArea) expContent.getChildren().get(1)).setText(sw.toString());
+        }
 
         // Set expandable Exception into the dialog pane.
         alert.getDialogPane().setExpandableContent(expContent);


### PR DESCRIPTION
#4 が前提。
エラーダイアログの詳細ダイアログ部をFXMLに分離。
try-with-resources構文を利用した書き方に変更。